### PR TITLE
Implement email template styles

### DIFF
--- a/src/hooks/send-email-confirmation.js
+++ b/src/hooks/send-email-confirmation.js
@@ -1,49 +1,50 @@
 // Use this hook to manipulate incoming or outgoing data.
 // For more information on hooks see: http://docs.feathersjs.com/api/hooks.html
-const fs    = require('fs');
-const hogan = require('hogan.js');
+const fs        = require('fs');
+const hogan     = require('hogan.js');
+const templates = {
+    html: fs.readFileSync('src/templates/email-confirmation-html.hogan', 'utf8'),
+    text: fs.readFileSync('src/templates/email-confirmation-text.hogan', 'utf8'),
+    partials: {
+        'body-open': fs.readFileSync('src/templates/partials/email-body-open.hogan', 'utf8'),
+        'body-close': fs.readFileSync('src/templates/partials/email-body-close.hogan', 'utf8'),
+        'footer': fs.readFileSync('src/templates/partials/email-footer.hogan', 'utf8'),
+        'header': fs.readFileSync('src/templates/partials/email-header.hogan', 'utf8'),
+        'social-contact': fs.readFileSync('src/templates/partials/email-social-contact.hogan', 'utf8'),
+        'styles': fs.readFileSync('src/templates/partials/email-styles.hogan', 'utf8'),
+    }
+}
 
 module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
     return function sendEmailConfirmation(hook) {
         return new Promise((rsv, rej) => {
-            fs.readFile('src/templates/email-confirmation-html.hogan', (err, htmlTemplate) => {
-                if (err) {
-                    return rej(err);
+            const app              = hook.app;
+            const transporter      = app.get('nodemailerService');
+            const fromEmail        = app.get('fromEmail');
+            const testToEmail      = app.get('testToEmail');
+            const confirmationLink = app.get('linksUrl') + '/confirm?id=';
+            const htmlEmail        = hogan.compile(templates.html);
+            const textEmail        = hogan.compile(templates.text);
+            const context          = Object.assign({confirmationLink: confirmationLink}, hook.data);
+
+            transporter.sendMail({
+                from:    fromEmail,
+                to:      testToEmail || context.email,
+                subject: 'Please confirm your donation offer to aid Puerto Rico',
+                text:    textEmail.render(context, templates.partials),
+                html:    htmlEmail.render(context, templates.partials),
+                ses:     {
+                    Tags: [{
+                        Name:  'type',
+                        Value: 'confirmation'
+                    }]
                 }
-                fs.readFile('src/templates/email-confirmation-text.hogan', (err, textTemplate) => {
-                    if (err) {
-                        return rej(err);
-                    }
+            }, (err) => {
+                if (err) {
+                    return rej(new Error('env:' + process.env.NODE_ENV + ' ' + JSON.stringify(err)));
+                }
 
-                    const app              = hook.app;
-                    const transporter      = app.get('nodemailerService');
-                    const fromEmail        = app.get('fromEmail');
-                    const testToEmail      = app.get('testToEmail');
-                    const confirmationLink = app.get('linksUrl') + '/confirm?id=';
-                    const htmlEmail        = hogan.compile(htmlTemplate.toString());
-                    const textEmail        = hogan.compile(textTemplate.toString());
-                    const context          = Object.assign({confirmationLink: confirmationLink}, hook.data);
-
-                    transporter.sendMail({
-                        from:    fromEmail,
-                        to:      testToEmail || context.email,
-                        subject: 'Please confirm your donation offer to aid Puerto Rico',
-                        text:    textEmail.render(context),
-                        html:    htmlEmail.render(context),
-                        ses:     {
-                            Tags: [{
-                                Name:  'type',
-                                Value: 'confirmation'
-                            }]
-                        }
-                    }, (err) => {
-                        if (err) {
-                            return rej(new Error('env:' + process.env.NODE_ENV + ' ' + JSON.stringify(err)));
-                        }
-
-                        return rsv(hook);
-                    });
-                });
+                return rsv(hook);
             });
         });
     };

--- a/src/hooks/send-email-thankyou.js
+++ b/src/hooks/send-email-thankyou.js
@@ -1,5 +1,17 @@
-const fs    = require('fs');
-const hogan = require('hogan.js');
+const fs        = require('fs');
+const hogan     = require('hogan.js');
+const templates = {
+    html: fs.readFileSync('src/templates/email-thankyou-html.hogan', 'utf8'),
+    text: fs.readFileSync('src/templates/email-thankyou-text.hogan', 'utf8'),
+    partials: {
+      'body-close': fs.readFileSync('src/templates/partials/email-body-close.hogan', 'utf8'),
+      'body-open': fs.readFileSync('src/templates/partials/email-body-open.hogan', 'utf8'),
+      'footer': fs.readFileSync('src/templates/partials/email-footer.hogan', 'utf8'),
+      'header': fs.readFileSync('src/templates/partials/email-header.hogan', 'utf8'),
+      'social-contact': fs.readFileSync('src/templates/partials/email-social-contact.hogan', 'utf8'),
+      'styles': fs.readFileSync('src/templates/partials/email-styles.hogan', 'utf8'),
+    },
+}
 
 module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
     return function sendEmailThankyou(hook) {
@@ -8,43 +20,32 @@ module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
                 return rsv(hook);
             }
 
-            fs.readFile('src/templates/email-thankyou-html.hogan', (err, htmlTemplate) => {
+            const app         = hook.app;
+            const transporter = app.get('nodemailerService');
+            const fromEmail   = app.get('fromEmail');
+            const testToEmail = app.get('testToEmail');
+            const htmlEmail   = hogan.compile(templates.html);
+            const textEmail   = hogan.compile(templates.text);
+            const context     = hook.result.donationOffer;
+
+            transporter.sendMail({
+                from:    fromEmail,
+                to:      testToEmail || context.email,
+                subject: 'Thank you for confirming your donation offer',
+                text:    textEmail.render(context, templates.partials),
+                html:    htmlEmail.render(context, templates.partials),
+                ses:     {
+                    Tags: [{
+                        Name:  'type',
+                        Value: 'thankyou'
+                    }]
+                }
+            }, (err) => {
                 if (err) {
                     return rej(err);
                 }
-                fs.readFile('src/templates/email-thankyou-text.hogan', (err, textTemplate) => {
-                    if (err) {
-                        return rej(err);
-                    }
 
-                    const app         = hook.app;
-                    const transporter = app.get('nodemailerService');
-                    const fromEmail   = app.get('fromEmail');
-                    const testToEmail = app.get('testToEmail');
-                    const htmlEmail   = hogan.compile(htmlTemplate.toString());
-                    const textEmail   = hogan.compile(textTemplate.toString());
-                    const context     = hook.result.donationOffer;
-
-                    transporter.sendMail({
-                        from:    fromEmail,
-                        to:      testToEmail || context.email,
-                        subject: 'Thank you for confirming your donation offer',
-                        text:    textEmail.render(context),
-                        html:    htmlEmail.render(context),
-                        ses:     {
-                            Tags: [{
-                                Name:  'type',
-                                Value: 'thankyou'
-                            }]
-                        }
-                    }, (err) => {
-                        if (err) {
-                            return rej(err);
-                        }
-
-                        return rsv(hook);
-                    });
-                });
+                return rsv(hook);
             });
         });
     };

--- a/src/templates/email-confirmation-html.hogan
+++ b/src/templates/email-confirmation-html.hogan
@@ -1,64 +1,82 @@
 <!DOCTYPE html>
 <html>
-<head>
+
+  <head>
     <meta charset="utf-8" />
-</head>
-<body>
-<p>
-    Dear {{fullname}}:<br />
-    <br />
-    Thank you for your offer to make the following donation to PRFAA. Please confirm the information below, which
-    details the donation you are offering.
-</p>
-<table>
-    <tr>
-        <td>Donator type:</td>
+    {{> styles}}
+  </head>
+
+  <body bgcolor="#FFFFFF">
+    {{> header}}
+
+    {{!-- Hogan does not accept partial blocks,
+          so wrapping markup must be split. --}}
+    {{> body-open}}
+
+    <p class="lead">Dear {{fullname}}:</p>
+
+    <p>
+      Thank you for your offer to make the following donation to PRFAA.
+      Please confirm the information below, which details the donation
+      you are offering.
+    </p>
+
+    <table class="content-table">
+      <tr>
+        <td>Donor type:</td>
         <td>{{organizationType}}</td>
-    </tr>
-    {{#organizationName}}
-    <tr>
+      </tr>
+      {{#organizationName}}
+      <tr>
         <td>Organization:</td>
         <td>{{organizationName}}</td>
-    </tr>
-    {{/organizationName}}
-    <tr>
+      </tr>
+      {{/organizationName}}
+      <tr>
         <td>Phone:</td>
         <td>{{phoneNumber}}</td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td>Category:</td>
         <td>{{donationCategory}}</td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td>Description:</td>
         <td>{{detailedDescription}}</td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td>Location:</td>
         <td>{{locationOfDonation}}</td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
         <td>Zip:</td>
         <td>{{zipCode}}</td>
-    </tr>
-    {{#transportationNeed}}
-    <tr>
+      </tr>
+      {{#transportationNeed}}
+      <tr>
         <td>Needs transported via:</td>
         <td>{{transportationType}}</td>
-    </tr>
-    {{/transportationNeed}}
-    <tr>
+      </tr>
+      {{/transportationNeed}}
+      <tr>
         <td>Notes:</td>
         <td>{{notes}}</td>
-    </tr>
-</table>
-<p>
-    Click here to confirm the above information: <a href="{{confirmationLink}}{{confirmationCode}}">Confirm My
-    Donation</a>
-</p>
-<p>
-    Thank you for your support!
-    PRFAA
-</p>
-</body>
+      </tr>
+    </table>
+
+    <p>
+      <a href="{{confirmationLink}}{{confirmationCode}}" class="btn btn-block">Click here to confirm your donation</a>
+    </p>
+
+    <p>
+      Thank you for your support!<br/>
+      &mdash; PRFAA
+    </p>
+
+    {{> social-contact}}
+    {{> body-close}}
+
+    {{> footer}}
+  </body>
+
 </html>

--- a/src/templates/email-thankyou-html.hogan
+++ b/src/templates/email-thankyou-html.hogan
@@ -13,7 +13,7 @@
           so wrapping markup must be split. --}}
     {{> body-open}}
 
-    <h2>Dear {{fullname}}:</h2>
+    <p class="lead">Dear {{fullname}}:</p>
     <p>Thank you for confirming you donation offer to PRFAA. One of our team members will be in contact with you to arrange further details.</p>
     <p>Thank you again for your support!<br />&mdash; PRFAA</p>
 

--- a/src/templates/email-thankyou-html.hogan
+++ b/src/templates/email-thankyou-html.hogan
@@ -1,18 +1,26 @@
 <!DOCTYPE html>
 <html>
-<head>
+
+  <head>
     <meta charset="utf-8" />
-</head>
-<body>
-<p>
-    Dear {{fullname}}:<br />
-    <br />
-    Thank you for confirming you donation offer to PRFAA. One of our team members will be in contact with you to arrange
-    further details.
-</p>
-<p>
-    Thank you again for your support!
-    PRFAA
-</p>
-</body>
+    {{> styles}}
+  </head>
+
+  <body bgcolor="#FFFFFF">
+    {{> header}}
+
+    {{!-- Hogan does not accept partial blocks,
+          so wrapping markup must be split. --}}
+    {{> body-open}}
+
+    <h2>Dear {{fullname}}:</h2>
+    <p>Thank you for confirming you donation offer to PRFAA. One of our team members will be in contact with you to arrange further details.</p>
+    <p>Thank you again for your support!<br />&mdash; PRFAA</p>
+
+    {{> social-contact}}
+    {{> body-close}}
+
+    {{> footer}}
+  </body>
+
 </html>

--- a/src/templates/partials/email-body-close.hogan
+++ b/src/templates/partials/email-body-close.hogan
@@ -1,0 +1,8 @@
+            </td>
+          </tr>
+        </table>
+      </div>
+    </td>
+    <td></td>
+  </tr>
+</table><!-- /BODY -->

--- a/src/templates/partials/email-body-open.hogan
+++ b/src/templates/partials/email-body-open.hogan
@@ -1,0 +1,9 @@
+<!-- BODY -->
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" bgcolor="#FFFFFF">
+      <div class="content">
+        <table>
+          <tr>
+            <td>

--- a/src/templates/partials/email-footer.hogan
+++ b/src/templates/partials/email-footer.hogan
@@ -1,0 +1,21 @@
+<!-- FOOTER -->
+<table class="footer-wrap">
+  <tr>
+    <td></td>
+    <td class="container">
+      <div class="content">
+        <table>
+          <tr>
+            <td align="center">
+              <p>
+                <a href="http://prfaa.pr.gov/">PRFAA Website</a> | <a href="https://prfaa.help/">PRFAA Help and Donate</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </td>
+    <td></td>
+  </tr>
+</table><!-- /FOOTER -->
+

--- a/src/templates/partials/email-header.hogan
+++ b/src/templates/partials/email-header.hogan
@@ -1,11 +1,11 @@
 <!-- HEADER -->
-<table class="head-wrap" bgcolor="#00B0F0">
+<table class="head-wrap" bgcolor="#DDDDDD">
   <tr>
     <td></td>
     <td class="header container" >
 
       <div class="content">
-        <table bgcolor="#00B0F0">
+        <table bgcolor="#DDDDDD">
           <tr>
             <td align="center">
               <h5>Puerto Rico Federal Affairs Administration</h5>

--- a/src/templates/partials/email-header.hogan
+++ b/src/templates/partials/email-header.hogan
@@ -1,0 +1,21 @@
+<!-- HEADER -->
+<table class="head-wrap" bgcolor="#00B0F0">
+  <tr>
+    <td></td>
+    <td class="header container" >
+
+      <div class="content">
+        <table bgcolor="#00B0F0">
+          <tr>
+            <td align="center">
+              <h5>Puerto Rico Federal Affairs Administration</h5>
+            </td>
+          </tr>
+        </table>
+      </div>
+
+    </td>
+    <td></td>
+  </tr>
+</table><!-- /HEADER -->
+

--- a/src/templates/partials/email-social-contact.hogan
+++ b/src/templates/partials/email-social-contact.hogan
@@ -1,0 +1,38 @@
+<!-- SOCIAL & CONTACT -->
+<table class="social" width="100%">
+  <tr>
+    <td>
+      <!-- column 1 -->
+      <table align="left" class="column">
+        <tr>
+          <td>				
+
+            <h5 class="">Connect with Us:</h5>
+            <p class=""><a href="#" class="soc-btn fb">Facebook</a> <a href="#" class="soc-btn tw">Twitter</a> <a href="#" class="soc-btn gp">Google+</a></p>
+
+
+          </td>
+        </tr>
+      </table><!-- /column 1 -->	
+
+      <!-- column 2 -->
+      <table align="left" class="column">
+        <tr>
+          <td>				
+
+            <h5 class="">Contact Info:</h5>												
+            <p>
+              Office Number: <strong>(202) 778-0710</strong><br/>
+              Fax Number: <strong>(202) 778-0721</strong><br/>
+              General Inquiries: <strong><a href="emailto:info@prfaa.pr.gov">info@prfaa.pr.gov</a></strong>
+            </p>
+
+          </td>
+        </tr>
+      </table><!-- /column 2 -->
+
+      <span class="clear"></span>	
+
+    </td>
+  </tr>
+</table><!-- /SOCIAL & CONTACT -->

--- a/src/templates/partials/email-styles.hogan
+++ b/src/templates/partials/email-styles.hogan
@@ -1,0 +1,233 @@
+<style>
+    /* ------------------------------------- 
+            GLOBAL 
+    ------------------------------------- */
+    * { 
+        margin:0;
+        padding:0;
+    }
+    * { font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; }
+
+    img { 
+        max-width: 100%; 
+    }
+    .collapse {
+        margin:0;
+        padding:0;
+    }
+    body {
+        -webkit-font-smoothing:antialiased; 
+        -webkit-text-size-adjust:none; 
+        width: 100%!important; 
+        height: 100%;
+    }
+
+
+    /* ------------------------------------- 
+            ELEMENTS 
+    ------------------------------------- */
+    a { color: #2BA6CB;}
+
+    .btn {
+        text-decoration:none;
+        color: #FFF;
+        background-color: #00B0F0;
+        padding:10px 16px;
+        font-weight:bold;
+        margin-right:10px;
+        text-align:center;
+        cursor:pointer;
+        display: inline-block;
+    }
+
+    .btn.btn-block {
+        display: block;
+    }
+
+    p.callout {
+        padding:15px;
+        background-color:#ECF8FF;
+        margin-bottom: 15px;
+    }
+    .callout a {
+        font-weight:bold;
+        color: #2BA6CB;
+    }
+
+    table.social {
+    /* 	padding:15px; */
+        background-color: #ebebeb;
+        
+    }
+    .social .soc-btn {
+        padding: 3px 7px;
+        font-size:12px;
+        margin-bottom:10px;
+        text-decoration:none;
+        color: #FFF;font-weight:bold;
+        display:block;
+        text-align:center;
+    }
+    a.fb { background-color: #3B5998!important; }
+    a.tw { background-color: #1daced!important; }
+    a.gp { background-color: #DB4A39!important; }
+    a.ms { background-color: #000!important; }
+
+    .sidebar .soc-btn { 
+        display:block;
+        width:100%;
+    }
+
+    /* ------------------------------------- 
+            HEADER 
+    ------------------------------------- */
+    table.head-wrap { width: 100%; }
+
+    .header.container table td.logo { padding: 15px; }
+    .header.container table td.label { padding: 15px; padding-left:0px;}
+    .header.container h5 { color: #FFF; }
+
+
+    /* ------------------------------------- 
+            BODY 
+    ------------------------------------- */
+    table.body-wrap { width: 100%;}
+    table.content-table { border: 1px solid #BBBBBB; }
+    table.content-table td { border: 1px solid #BBBBBB; padding: 4px 6px; }
+
+
+    /* ------------------------------------- 
+            FOOTER 
+    ------------------------------------- */
+    table.footer-wrap { width: 100%;	clear:both!important;
+    }
+    .footer-wrap .container td.content  p { border-top: 1px solid rgb(215,215,215); padding-top:15px;}
+    .footer-wrap .container td.content p {
+        font-size:10px;
+        font-weight: bold;
+        
+    }
+
+
+    /* ------------------------------------- 
+            TYPOGRAPHY 
+    ------------------------------------- */
+    h1,h2,h3,h4,h5,h6 {
+    font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif; line-height: 1.1; margin-bottom:15px; color:#000;
+    }
+    h1 small, h2 small, h3 small, h4 small, h5 small, h6 small { font-size: 60%; color: #6f6f6f; line-height: 0; text-transform: none; }
+
+    h1 { font-weight:200; font-size: 44px;}
+    h2 { font-weight:200; font-size: 37px;}
+    h3 { font-weight:500; font-size: 27px;}
+    h4 { font-weight:500; font-size: 23px;}
+    h5 { font-weight:900; font-size: 17px;}
+    h6 { font-weight:900; font-size: 14px; text-transform: uppercase; color:#444;}
+
+    .collapse { margin:0!important;}
+
+    p, ul, table.content-table { 
+        margin-bottom: 10px; 
+        font-weight: normal; 
+        font-size:14px; 
+        line-height:1.6;
+    }
+    p.lead { font-size:17px; }
+    p.last { margin-bottom:0px;}
+
+    ul li {
+        margin-left:5px;
+        list-style-position: inside;
+    }
+
+    /* ------------------------------------- 
+            SIDEBAR 
+    ------------------------------------- */
+    ul.sidebar {
+        background:#ebebeb;
+        display:block;
+        list-style-type: none;
+    }
+    ul.sidebar li { display: block; margin:0;}
+    ul.sidebar li a {
+        text-decoration:none;
+        color: #666;
+        padding:10px 16px;
+    /* 	font-weight:bold; */
+        margin-right:10px;
+    /* 	text-align:center; */
+        cursor:pointer;
+        border-bottom: 1px solid #777777;
+        border-top: 1px solid #FFFFFF;
+        display:block;
+        margin:0;
+    }
+    ul.sidebar li a.last { border-bottom-width:0px;}
+    ul.sidebar li a h1,ul.sidebar li a h2,ul.sidebar li a h3,ul.sidebar li a h4,ul.sidebar li a h5,ul.sidebar li a h6,ul.sidebar li a p { margin-bottom:0!important;}
+
+
+
+    /* --------------------------------------------------- 
+            RESPONSIVENESS
+            Nuke it from orbit. It's the only way to be sure. 
+    ------------------------------------------------------ */
+
+    /* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
+    .container {
+        display:block!important;
+        max-width:600px!important;
+        margin:0 auto!important; /* makes it centered */
+        clear:both!important;
+    }
+
+    /* This should also be a block element, so that it will fill 100% of the .container */
+    .content {
+        padding:15px;
+        max-width:600px;
+        margin:0 auto;
+        display:block; 
+    }
+
+    /* Let's make sure tables in the content area are 100% wide */
+    .content table { width: 100%; }
+
+
+    /* Odds and ends */
+    .column {
+        width: 300px;
+        float:left;
+    }
+    .column tr td { padding: 15px; }
+    .column-wrap { 
+        padding:0!important; 
+        margin:0 auto; 
+        max-width:600px!important;
+    }
+    .column table { width:100%;}
+    .social .column {
+        width: 280px;
+        min-width: 279px;
+        float:left;
+    }
+
+    /* Be sure to place a .clear element after each set of columns, just to be safe */
+    .clear { display: block; clear: both; }
+
+
+    /* ------------------------------------------- 
+            PHONE
+            For clients that support media queries.
+            Nothing fancy. 
+    -------------------------------------------- */
+    @media only screen and (max-width: 600px) {
+        
+        a[class="btn"] { display:block!important; margin-bottom:10px!important; background-image:none!important; margin-right:0!important;}
+
+        div[class="column"] { width: auto!important; float:none!important;}
+        
+        table.social div[class="column"] {
+            width:auto!important;
+        }
+
+    }
+</style>

--- a/src/templates/partials/email-styles.hogan
+++ b/src/templates/partials/email-styles.hogan
@@ -85,7 +85,6 @@
 
     .header.container table td.logo { padding: 15px; }
     .header.container table td.label { padding: 15px; padding-left:0px;}
-    .header.container h5 { color: #FFF; }
 
 
     /* ------------------------------------- 


### PR DESCRIPTION
Implements SoPR/prfaa-donations-frontend#11.

Also, I took the liberty of refactoring `send-email-confirmation.js` and `send-email-thankyou.js` to load templates on boot. This avoids I/O during the request’s lifecycle, as these files only need to be read once.

Additionally, I broke down shared components of the email templates into partials, which now live in the `src/templates/partials/` directory. I dumped [the Zurb basic email template CSS](https://zurb.com/playground/projects/responsive-email-templates/basic.html) in a styles partial and tweaked them just a bit to fit the brand.

Here’s what the confirmation email looks like:
![screenshot of confirmation email](https://cl.ly/0m3m2q2a1d3b/Image%202017-10-01%20at%2012.31.06%20AM.png)

And the thank you email:
![screenshot of thank you email](https://cl.ly/0A0p3h3P1v1x/Image%202017-10-01%20at%2012.40.31%20AM.png)