### PR TITLE
Test & Linting Automation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,12 @@
             "error",
             "unix"
         ],
+        "no-unused-vars": [
+            "error",
+            {
+              "args": "none"
+            }
+        ],
         "quotes": [
             "error",
             "single"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,12 @@
         "start": "node src/",
         "mocha": "mocha test/ --recursive"
     },
+    "pre-push": [
+        "mocha"
+    ],
+    "pre-commit": [
+        "eslint"
+    ],
     "dependencies": {
         "aws-sdk": "^2.122.0",
         "babel-polyfill": "^6.26.0",
@@ -59,6 +65,8 @@
     "devDependencies": {
         "eslint": "^4.7.2",
         "mocha": "^3.5.3",
+        "pre-commit": "^1.2.2",
+        "pre-push": "^0.1.1",
         "request": "^2.82.0",
         "request-promise": "^4.2.2"
     },

--- a/src/hooks/send-email-confirmation.js
+++ b/src/hooks/send-email-confirmation.js
@@ -12,8 +12,8 @@ const templates = {
         'header': fs.readFileSync('src/templates/partials/email-header.hogan', 'utf8'),
         'social-contact': fs.readFileSync('src/templates/partials/email-social-contact.hogan', 'utf8'),
         'styles': fs.readFileSync('src/templates/partials/email-styles.hogan', 'utf8'),
-    }
-}
+    },
+};
 
 module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
     return function sendEmailConfirmation(hook) {

--- a/src/hooks/send-email-thankyou.js
+++ b/src/hooks/send-email-thankyou.js
@@ -4,14 +4,14 @@ const templates = {
     html: fs.readFileSync('src/templates/email-thankyou-html.hogan', 'utf8'),
     text: fs.readFileSync('src/templates/email-thankyou-text.hogan', 'utf8'),
     partials: {
-      'body-close': fs.readFileSync('src/templates/partials/email-body-close.hogan', 'utf8'),
-      'body-open': fs.readFileSync('src/templates/partials/email-body-open.hogan', 'utf8'),
-      'footer': fs.readFileSync('src/templates/partials/email-footer.hogan', 'utf8'),
-      'header': fs.readFileSync('src/templates/partials/email-header.hogan', 'utf8'),
-      'social-contact': fs.readFileSync('src/templates/partials/email-social-contact.hogan', 'utf8'),
-      'styles': fs.readFileSync('src/templates/partials/email-styles.hogan', 'utf8'),
+        'body-close': fs.readFileSync('src/templates/partials/email-body-close.hogan', 'utf8'),
+        'body-open': fs.readFileSync('src/templates/partials/email-body-open.hogan', 'utf8'),
+        'footer': fs.readFileSync('src/templates/partials/email-footer.hogan', 'utf8'),
+        'header': fs.readFileSync('src/templates/partials/email-header.hogan', 'utf8'),
+        'social-contact': fs.readFileSync('src/templates/partials/email-social-contact.hogan', 'utf8'),
+        'styles': fs.readFileSync('src/templates/partials/email-styles.hogan', 'utf8'),
     },
-}
+};
 
 module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
     return function sendEmailThankyou(hook) {

--- a/src/hooks/validate-confirm.js
+++ b/src/hooks/validate-confirm.js
@@ -1,6 +1,5 @@
 // Use this hook to manipulate incoming or outgoing data.
 // For more information on hooks see: http://docs.feathersjs.com/api/hooks.html
-const validator           = require('validator');
 const jsonschemaValidator = require('jsonschema').Validator;
 const v                   = new jsonschemaValidator();
 const confirmModel        = require('../models/confirm.model');

--- a/test/hooks/send-email-confirmation.test.js
+++ b/test/hooks/send-email-confirmation.test.js
@@ -14,10 +14,8 @@ describe('\'sendEmailConfirmation\' hook', () => {
                                 return cb();
                             }
                         };
-                        break;
                     case 'linksUrl':
                         return;
-                        break;
                     }
                 },
             },

--- a/test/hooks/send-email-thankyou.test.js
+++ b/test/hooks/send-email-thankyou.test.js
@@ -14,10 +14,8 @@ describe('\'sendEmailThankyou\' hook', () => {
                                 return cb();
                             }
                         };
-                        break;
                     case 'linksUrl':
                         return;
-                        break;
                     }
                 },
             },


### PR DESCRIPTION
This PR uses [`pre-commit`](https://www.npmjs.org/package/pre-commit) to run the `eslint` task and [`pre-push`](https://www.npmjs.org/package/pre-push) to run the `mocha` task.

---

_For anybody interested in some of the minutiae of this implementation:_

Currently, it’ll run the `eslint` task as-is before committing. That is to say that if you have **unstaged** changes that break the linter, you cannot commit your staged changes. Personally, I would prefer only staged changes are linted. I tried using [`lint-staged`](https://www.npmjs.org/package/lint-staged), but it kept linting everything (staged and unstaged). Its docs mention it was designed to work with [`husky`](https://www.npmjs.org/package/husky), but that it should work with other git hook solutions.

I tried it with and without `husky` and the behavior persisted: it linted staged _and unstaged_ changes. So I rolled back those two libs, since `husky` seems to do a whole lot more than what we need.